### PR TITLE
fix: postgresql enum type filter `where` instead of `whereLike`

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -168,7 +168,7 @@ export class Resource extends BaseResource {
         && ['date', 'datetime'].includes(filter.property.type())
       ) {
         q.whereBetween(key, [filter.value.from, filter.value.to]);
-      } else if (filter.property.type() === 'string') {
+      } else if (filter.property.type() === 'string' && !filter.property.availableValues) {
         if (this.dialect === 'postgresql') {
           q.whereILike(key, `%${filter.value}%`);
         } else {


### PR DESCRIPTION
This fixes

```
error: select * from "public"."chat_messages" where "type" ilike $1 order by "id" desc limit $2 - operator does not exist: "MessageTypes" ~~* unknown
    at Parser.parseErrorMessage (/Users/clszzyh/Documents/Projects/Mine/hopi/node_modules/pg-protocol/src/parser.ts:369:69)
    at Parser.handlePacket (/Users/clszzyh/Documents/Projects/Mine/hopi/node_modules/pg-protocol/src/parser.ts:188:21)
    at Parser.parse (/Users/clszzyh/Documents/Projects/Mine/hopi/node_modules/pg-protocol/src/parser.ts:103:30)
    at Socket.<anonymous> (/Users/clszzyh/Documents/Projects/Mine/hopi/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:519:28)
    at Socket.emit (node:domain:488:12)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
```