### PR TITLE
fix(postgres-parser): use current schema name in `getProperties` method

### DIFF
--- a/src/dialects/base-database.parser.ts
+++ b/src/dialects/base-database.parser.ts
@@ -52,7 +52,7 @@ export class BaseDatabaseParser {
     throw new Error('Implement "getResources" method for your database parser!');
   }
 
-  public async getProperties(table: string): Promise<any[]> {
+  public async getProperties(table: string, schemaName: string): Promise<any[]> {
     throw new Error('Implement "getProperties" method for your database parser!');
   }
 }

--- a/src/dialects/postgres.parser.ts
+++ b/src/dialects/postgres.parser.ts
@@ -121,7 +121,7 @@ export class PostgresParser extends BaseDatabaseParser {
             this.connectionOptions.database,
             schemaName,
             tableName,
-            await this.getProperties(tableName),
+            await this.getProperties(tableName, schemaName),
           );
 
           return resourceMetadata;
@@ -137,7 +137,7 @@ export class PostgresParser extends BaseDatabaseParser {
     return resources.filter(Boolean) as ResourceMetadata[];
   }
 
-  public async getProperties(table: string) {
+  public async getProperties(table: string, schemaName: string) {
     const query = this.knex
       .from('information_schema.columns as col')
       .select(
@@ -156,7 +156,7 @@ export class PostgresParser extends BaseDatabaseParser {
         .on('tco.constraint_name', 'kcu.constraint_name')
         .on('tco.constraint_schema', 'kcu.constraint_schema')
         .onVal('tco.constraint_type', 'PRIMARY KEY'))
-      .where('col.table_schema', 'public')
+      .where('col.table_schema', schemaName)
       .where('col.table_name', table);
 
     const columns = await query;


### PR DESCRIPTION
Using the current schema in postgres parser has been added here: https://github.com/SoftwareBrothers/adminjs-sql/pull/6 but It's still missing in `getProperties` method. 