### PR TITLE
fix: availableValues regression

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -168,7 +168,7 @@ export class Resource extends BaseResource {
         && ['date', 'datetime'].includes(filter.property.type())
       ) {
         q.whereBetween(key, [filter.value.from, filter.value.to]);
-      } else if (filter.property.type() === 'string' && !filter.property.availableValues) {
+      } else if (filter.property.type() === 'string' && !filter.property.availableValues()) {
         if (this.dialect === 'postgresql') {
           q.whereILike(key, `%${filter.value}%`);
         } else {


### PR DESCRIPTION
availableValues is a function so it's always not null. Therefore, unless it is called, this block never gets called and the filter always uses = and never like.