### PR TITLE
Fix: Using provided schema if present

### DIFF
--- a/src/dialects/postgres.parser.ts
+++ b/src/dialects/postgres.parser.ts
@@ -85,6 +85,9 @@ export class PostgresParser extends BaseDatabaseParser {
   }
 
   public async getSchema() {
+    if (this.connectionOptions.schema) {
+      return this.connectionOptions.schema;
+    }
     const query = await this.knex.raw('SELECT current_schema() AS schema_name');
     const result = await query;
 


### PR DESCRIPTION
When providing the `schema` option to force using specified schema, this option is ignored in `postgres.parsers.ts` file.
This PR fixes this so that forced schema is prefered.

```ts
const pgbossDb = await new Adapter('postgresql', {
  connectionString: dbUrl,
  database: 'database',
  schema: 'pgboss',
}).init();
```